### PR TITLE
Move to using multi-azs

### DIFF
--- a/cucumber/features/activegate.feature
+++ b/cucumber/features/activegate.feature
@@ -6,9 +6,9 @@ Feature: ActiveGate Feature
         Given That synth has run
         When the file DynatraceActivegateStack.template.json exists
         Then the AWS::EC2::VPC resource with the CIDR range 10.0.0.0/16 should exist
-        And 2 AWS::EC2::Subnet should exist
-        And 2 AWS::EC2::RouteTable should exist
-        And 2 AWS::EC2::SubnetRouteTableAssociation should exist
-        And 2 AWS::EC2::Route should exist
-        And 1 AWS::EC2::EIP should exist
-        And 1 AWS::EC2::NatGateway should exist
+        And 6 AWS::EC2::Subnet should exist
+        And 6 AWS::EC2::RouteTable should exist
+        And 6 AWS::EC2::SubnetRouteTableAssociation should exist
+        And 6 AWS::EC2::Route should exist
+        And 3 AWS::EC2::EIP should exist
+        And 3 AWS::EC2::NatGateway should exist

--- a/lib/dynatrace-activegate-stack.ts
+++ b/lib/dynatrace-activegate-stack.ts
@@ -12,7 +12,7 @@ export class DynatraceActivegateStack extends cdk.Stack {
     super(scope, id, props);
 
     const vpc = new ec2.Vpc(this, 'vpc', {
-      maxAzs: 1
+      availabilityZones: ["eu-west-2a", "eu-west-2b", "eu-west-2c"]
     });
 
     const userData = ec2.UserData.forLinux();


### PR DESCRIPTION
Change has been deployed manually as it required and destruction of the cloudformation templates which the workflows aren't geared for.