### PR TITLE
Update codeowners with new fog team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @govuk-one-login/observability
+* @govuk-one-login/fog


### PR DESCRIPTION
Consolidating GitHub teams by adding the new "fog" team and will eventually remove all teams