### PR TITLE
Updated reviewers to be fog group and changed assignee from Joe

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,11 +11,11 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 3
     assignees:
-      - "two-first-names"
+      - "chrisdodd93"
     target-branch: main
     versioning-strategy: lockfile-only
     reviewers:
-      - "govuk-one-login/observability"
+      - "govuk-one-login/fog"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
@@ -25,9 +25,9 @@ updates:
     versioning-strategy: lockfile-only
     open-pull-requests-limit: 3
     assignees:
-      - "two-first-names"
+      - "chrisdodd93"
     reviewers:
-      - "govuk-one-login/observability"
+      - "govuk-one-login/fog"
   - package-ecosystem: "github-actions"
     # Workflow files stored in the
     # default location of `.github/workflows`
@@ -36,7 +36,7 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 3
     assignees:
-      - "two-first-names"
+      - "chrisdodd93"
     reviewers:
-      - "govuk-one-login/observability"
+      - "govuk-one-login/fog"
 


### PR DESCRIPTION
Noticed in one of the PRs that dependabot was failing because it was trying to assign the observability github group as a reviewer, but this was changed to fog a while ago.
The assignee was also still listed as Joe, which I'm changing to be myself.